### PR TITLE
Fix issue with diff_nhood_enrichment when more than two conditions are present

### DIFF
--- a/src/cellcharter/gr/_nhood.py
+++ b/src/cellcharter/gr/_nhood.py
@@ -344,8 +344,8 @@ def diff_nhood_enrichment(
                         pbar.update(1)
 
                     expected = np.stack(expected, axis=0)
-                    pvalues = _empirical_pvalues(observed, expected)
-                    result[result_key]["pvalue"] = pvalues
+                    tmp_pvalues = _empirical_pvalues(observed, expected)
+                    result[result_key]["pvalue"] = tmp_pvalues
 
     if copy:
         return result


### PR DESCRIPTION
`pvalues` is a boolean passed as function parameter. The variable gets overwritten in the inner loop and then fails in the next iteration with 

```pytb
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-10-b8134094f274> in ?()
----> 1 cc.gr.diff_nhood_enrichment(
      2     adata_vis,
      3     cluster_key="niche_cellcharter_ct",
      4     condition_key="SM_simple",

/cfs/sturmgre/conda/envs/1368-0008_visium2/lib/python3.10/site-packages/cellcharter/gr/_nhood.py in ?(adata, cluster_key, condition_key, library_key, pvalues, n_perms, n_jobs, copy, **nhood_kwargs)
    306     for condition1, condition2 in combinations(conditions, 2):
    307         observed = enrichments[condition1] - enrichments[condition2]
    308         result_key = f"{condition1}_{condition2}"
    309         result[result_key] = {"enrichment": observed}
--> 310         if pvalues:
    311             samples1 = adata[adata.obs[condition_key] == condition1].obs[library_key].unique()
    312             samples2 = adata[adata.obs[condition_key] == condition2].obs[library_key].unique()
    313 

/cfs/sturmgre/conda/envs/1368-0008_visium2/lib/python3.10/site-packages/pandas/core/generic.py in ?(self)
   1575     @final
   1576     def __nonzero__(self) -> NoReturn:
-> 1577         raise ValueError(
   1578             f"The truth value of a {type(self).__name__} is ambiguous. "
   1579             "Use a.empty, a.bool(), a.item(), a.any() or a.all()."
   1580         )

ValueError: The truth value of a DataFrame is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
```

Simply renaming the variable should fix the issue. 