### PR TITLE
Rewrite of cc.pl.enrichment

### DIFF
--- a/src/cellcharter/gr/_group.py
+++ b/src/cellcharter/gr/_group.py
@@ -1,19 +1,27 @@
 from __future__ import annotations
 
+import concurrent.futures
+
 import numpy as np
 import pandas as pd
 from anndata import AnnData
 from squidpy._docs import d
+from tqdm import tqdm
 
 
-def _proportion(adata, id_key, val_key, normalize=True):
-    df = pd.pivot(adata.obs[[id_key, val_key]].value_counts().reset_index(), index=id_key, columns=val_key)
+def _proportion(obs, id_key, val_key, normalize=True):
+    df = pd.pivot(obs[[id_key, val_key]].value_counts().reset_index(), index=id_key, columns=val_key)
     df[df.isna()] = 0
     df.columns = df.columns.droplevel(0)
     if normalize:
         return df.div(df.sum(axis=1), axis=0)
     else:
         return df
+
+
+def _observed_permuted(annotations, group_key, label_key):
+    annotations[group_key] = annotations[group_key].sample(frac=1).reset_index(drop=True).values
+    return _proportion(annotations, id_key=label_key, val_key=group_key).reindex().T
 
 
 def _enrichment(observed, expected, log=True):
@@ -25,11 +33,25 @@ def _enrichment(observed, expected, log=True):
     return enrichment
 
 
+def _empirical_pvalues(observed, expected):
+    pvalues = np.zeros(observed.shape)
+    pvalues[observed.values > 0] = (
+        1 - np.sum(expected[:, observed.values > 0] < observed.values[observed.values > 0], axis=0) / expected.shape[0]
+    )
+    pvalues[observed.values < 0] = (
+        1 - np.sum(expected[:, observed.values < 0] > observed.values[observed.values < 0], axis=0) / expected.shape[0]
+    )
+    return pd.DataFrame(pvalues, columns=observed.columns, index=observed.index)
+
+
 @d.dedent
 def enrichment(
     adata: AnnData,
     group_key: str,
     label_key: str,
+    pvalues: bool = False,
+    n_perms: int = 1000,
+    n_jobs: int = -1,
     log: bool = True,
     observed_expected: bool = False,
     copy: bool = False,
@@ -61,9 +83,30 @@ def enrichment(
         - :attr:`anndata.AnnData.uns` ``['{group_key}_{label_key}_nhood_enrichment']`` - the above mentioned dict.
         - :attr:`anndata.AnnData.uns` ``['{group_key}_{label_key}_nhood_enrichment']['params']`` - the parameters used.
     """
-    observed = _proportion(adata, id_key=label_key, val_key=group_key).reindex().T
+    observed = _proportion(adata.obs, id_key=label_key, val_key=group_key).reindex().T
     observed[observed.isna()] = 0
-    expected = adata.obs[group_key].value_counts() / adata.shape[0]
+    if not pvalues:
+        expected = adata.obs[group_key].value_counts() / adata.shape[0]
+    else:
+        annotations = adata.obs.copy()
+
+        expected = []
+        with tqdm(total=n_perms) as pbar:
+            with concurrent.futures.ProcessPoolExecutor(max_workers=n_jobs) as executor:
+                futures = [
+                    executor.submit(_observed_permuted, annotations, group_key, label_key) for _ in range(n_perms)
+                ]
+
+                for future in concurrent.futures.as_completed(futures):
+                    expected.append(future.result())
+                    pbar.update(1)
+
+        expected = np.stack(expected, axis=0)
+
+        empirical_pvalues = _empirical_pvalues(observed, expected)
+
+        expected = np.mean(expected, axis=0)
+        expected = pd.DataFrame(expected, columns=observed.columns, index=observed.index)
 
     enrichment = _enrichment(observed, expected, log=log)
 
@@ -72,6 +115,9 @@ def enrichment(
     if observed_expected:
         result["observed"] = observed
         result["expected"] = expected
+
+    if pvalues:
+        result["pvalue"] = empirical_pvalues
 
     if copy:
         return result

--- a/tests/graph/test_group.py
+++ b/tests/graph/test_group.py
@@ -51,3 +51,20 @@ class TestEnrichment:
         assert expected.shape[0] == adata.obs[GROUP_KEY].cat.categories.shape[0]
         assert np.all((observed >= 0) & (observed <= 1))
         assert np.all((expected >= 0) & (expected <= 1))
+
+    def test_perm(self):
+        result_analytical = cc.gr.enrichment(
+            adata, group_key=GROUP_KEY, label_key=LABEL_KEY, pvalues=False, copy=True, observed_expected=True
+        )
+        result_perm = cc.gr.enrichment(
+            adata,
+            group_key=GROUP_KEY,
+            label_key=LABEL_KEY,
+            pvalues=True,
+            n_perms=5000,
+            observed_expected=True,
+            copy=True,
+        )
+        np.testing.assert_allclose(result_analytical["enrichment"], result_perm["enrichment"], atol=0.1)
+        np.testing.assert_allclose(result_analytical["observed"], result_perm["observed"], atol=0.1)
+        np.testing.assert_allclose(result_analytical["expected"], result_perm["expected"], atol=0.1)

--- a/tests/plotting/test_group.py
+++ b/tests/plotting/test_group.py
@@ -1,4 +1,10 @@
+import pytest
 import squidpy as sq
+
+try:
+    from matplotlib.colormaps import get_cmap
+except ImportError:
+    from matplotlib.pyplot import get_cmap
 
 import cellcharter as cc
 
@@ -7,6 +13,11 @@ LABEL_KEY = "Cell_class"
 key = f"{GROUP_KEY}_{LABEL_KEY}_enrichment"
 
 adata = sq.datasets.merfish()
+adata_empirical = adata.copy()
+cc.gr.enrichment(adata_empirical, group_key=GROUP_KEY, label_key=LABEL_KEY, pvalues=True, n_perms=1000)
+
+adata_analytical = adata.copy()
+cc.gr.enrichment(adata_analytical, group_key=GROUP_KEY, label_key=LABEL_KEY)
 
 
 class TestProportion:
@@ -24,25 +35,54 @@ class TestProportion:
 
 
 class TestPlotEnrichment:
-    def test_enrichment(self):
-        cc.gr.enrichment(adata, group_key=GROUP_KEY, label_key=LABEL_KEY)
-        cc.pl.enrichment(adata, group_key=GROUP_KEY, label_key=LABEL_KEY)
+    @pytest.mark.parametrize("adata_enrichment", [adata_analytical, adata_empirical])
+    def test_enrichment(self, adata_enrichment):
+        cc.pl.enrichment(adata_enrichment, group_key=GROUP_KEY, label_key=LABEL_KEY)
 
-        del adata.uns[key]
-
-    def test_params(self):
-        cc.gr.enrichment(adata, group_key=GROUP_KEY, label_key=LABEL_KEY)
-        cc.pl.enrichment(adata, group_key=GROUP_KEY, label_key=LABEL_KEY, label_cluster=False)
+    @pytest.mark.parametrize("adata_enrichment", [adata_analytical, adata_empirical])
+    @pytest.mark.parametrize("label_cluster", [False, True])
+    @pytest.mark.parametrize("groups", [None, adata.obs[GROUP_KEY].cat.categories[:3]])
+    @pytest.mark.parametrize("labels", [None, adata.obs[LABEL_KEY].cat.categories[:4]])
+    @pytest.mark.parametrize("size_threshold", [1, 2.5])
+    @pytest.mark.parametrize("palette", [None, "coolwarm", get_cmap("coolwarm")])
+    @pytest.mark.parametrize("figsize", [None, (10, 8)])
+    @pytest.mark.parametrize("alpha,edgecolor", [(1, "red"), (0.5, "blue")])
+    def test_params(
+        self, adata_enrichment, label_cluster, groups, labels, size_threshold, palette, figsize, alpha, edgecolor
+    ):
         cc.pl.enrichment(
-            adata,
+            adata_enrichment,
             group_key=GROUP_KEY,
             label_key=LABEL_KEY,
-            groups=adata.obs[GROUP_KEY].cat.categories[:3],
-            labels=adata.obs[LABEL_KEY].cat.categories[:4],
+            label_cluster=label_cluster,
+            groups=groups,
+            labels=labels,
+            size_threshold=size_threshold,
+            palette=palette,
+            figsize=figsize,
+            alpha=alpha,
+            edgecolor=edgecolor,
         )
 
-        del adata.uns[key]
+    def test_no_pvalues(self):
+        # If the enrichment data is not present, it should raise an error
+        with pytest.raises(ValueError):
+            cc.pl.enrichment(adata_analytical, "group_key", "label_key", show_pvalues=True)
+
+        with pytest.raises(ValueError):
+            cc.pl.enrichment(adata_analytical, "group_key", "label_key", significance=0.01)
+
+        with pytest.raises(ValueError):
+            cc.pl.enrichment(adata_analytical, "group_key", "label_key", significant_only=True)
 
     def test_obs_exp(self):
         cc.gr.enrichment(adata, group_key=GROUP_KEY, label_key=LABEL_KEY, observed_expected=True)
         cc.pl.enrichment(adata, group_key=GROUP_KEY, label_key=LABEL_KEY)
+
+    def test_enrichment_no_enrichment_data(self):
+        with pytest.raises(ValueError):
+            cc.pl.enrichment(adata, "group_key", "label_key")
+
+    def test_size_threshold_zero(self):
+        with pytest.raises(ValueError):
+            cc.pl.enrichment(adata_empirical, group_key=GROUP_KEY, label_key=LABEL_KEY, size_threshold=0)

--- a/tests/plotting/test_group.py
+++ b/tests/plotting/test_group.py
@@ -32,9 +32,7 @@ class TestPlotEnrichment:
 
     def test_params(self):
         cc.gr.enrichment(adata, group_key=GROUP_KEY, label_key=LABEL_KEY)
-        cc.pl.enrichment(adata, group_key=GROUP_KEY, label_key=LABEL_KEY, cluster_labels=False)
-        cc.pl.enrichment(adata, group_key=GROUP_KEY, label_key=LABEL_KEY, size_threshold=100)
-        cc.pl.enrichment(adata, group_key=GROUP_KEY, label_key=LABEL_KEY, color_threshold=0)
+        cc.pl.enrichment(adata, group_key=GROUP_KEY, label_key=LABEL_KEY, label_cluster=False)
         cc.pl.enrichment(
             adata,
             group_key=GROUP_KEY,


### PR DESCRIPTION
Complete rewrite of the `pl.enrichment` and adding the permutation-based computation of `gr.enrichment` to estimate pvalues.

- Removed dependency of `pl.enrichment` with scanpy's dotplot.
- p-values are shown by color (parameter `pvalues`)
- Possibility to select a significance threshold (parameter `significance `)
- Show also depleted label-group pairs (parameter `enriched_only`)
- Show only significant pairs based on the significance threshold (parameter `significant_only`)