### PR TITLE
Make all CellCharter's generated data serializable

### DIFF
--- a/src/cellcharter/tl/_autok.py
+++ b/src/cellcharter/tl/_autok.py
@@ -207,7 +207,7 @@ class ClusterAutoK:
             if use_rep is not None
             else adata.obsm["X_cellcharter"] if "X_cellcharter" in adata.obsm else adata.X
         )
-        return pd.Categorical(self.best_models[k].predict(X), categories=np.arange(k))
+        return pd.Categorical(self.best_models[k].predict(X).astype(str), categories=np.arange(k).astype(str))
 
     @property
     def persistent_attributes(self) -> List[str]:

--- a/src/cellcharter/tl/_gmm.py
+++ b/src/cellcharter/tl/_gmm.py
@@ -317,4 +317,4 @@ class Cluster(GaussianMixture):
             Number of clusters to predict using the fitted model. If ``None``, the number of clusters with the highest stability will be selected. If ``max_runs > 1``, the model with the largest marginal likelihood will be used among the ones fitted on ``k``.
         """
         X = adata.X if use_rep is None else adata.obsm[use_rep]
-        return pd.Categorical(super().predict(X), categories=np.arange(self.n_clusters))
+        return pd.Categorical(super().predict(X).astype(str), categories=np.arange(self.n_clusters).astype(str))


### PR DESCRIPTION
Fixes #88 

- Output cluster names as strings instead of integers
- Write a serializer for shapely polygons